### PR TITLE
Fix closing behavior when adjacent to empty delimiters.

### DIFF
--- a/lib/bracket-padder.coffee
+++ b/lib/bracket-padder.coffee
@@ -111,7 +111,7 @@ removePairs = (opening, closing) -> (str) ->
   if not closing
     closing = opening
 
-  regex = new RegExp("#{opening}([^#{opening}]+(?=#{closing}))#{closing}", 'g')
+  regex = new RegExp("#{opening}([^#{opening}]*(?=#{closing}))#{closing}", 'g')
   str.replace(regex, '')
 
 ###


### PR DESCRIPTION
This change fixes an edge case in the delimiter matching whereby empty delimiters were not matched. Given cursor position as `|`, `${ interpolated()| }` + <kbd>}</kbd> previously produced `${ interpolated()}| }`; with this change, it produces `${ interpolated() }|`.